### PR TITLE
Add basic home screen and test

### DIFF
--- a/__tests__/HomePage.test.js
+++ b/__tests__/HomePage.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import HomePage from '../src/HomePage';
+
+describe('HomePage', () => {
+  it('renders welcome message', () => {
+    const tree = renderer.create(<HomePage />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,6 @@
 import React from 'react';
-import { SafeAreaView, Text } from 'react-native';
+import HomePage from './HomePage';
 
-const App = () => (
-  <SafeAreaView>
-    <Text>Hello, SOTEVAS-CHAT!</Text>
-  </SafeAreaView>
-);
+const App = () => <HomePage />;
 
 export default App;

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SafeAreaView, Text } from 'react-native';
+
+const HomePage = () => (
+  <SafeAreaView>
+    <Text>Welcome to SOTEVAS-CHAT!</Text>
+  </SafeAreaView>
+);
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- add a minimal `HomePage` component and render it in `App`
- create a snapshot test for `HomePage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f83349e848321bf8f31e2e24727d5